### PR TITLE
User Icon

### DIFF
--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -13,7 +13,7 @@
         <div class="card-body d-flex flex-wrap">
             <div class="align-self-center text-center user-icon rounded-circle mr-3 bg-primary text-white" style="width: 50px; height: 50px;">
                 <div class="d-flex align-items-center text-center h-100">
-                    <i class="far fa-user fa-2x mx-auto"></i>
+                    <i class="fas fa-user fa-2x mx-auto"></i>
                 </div>
             </div>
             <div class="align-self-center pr-5 mr-auto">


### PR DESCRIPTION
# Beschreibung

Um die Ansicht den anderen Anwendungen anzugleichen, wird auch hier das Icon in der `Solid` Variante angezeigt.

## Ansicht
### Vorher:
![Bildschirmfoto 2022-05-07 um 10 26 45](https://user-images.githubusercontent.com/74987472/167246092-9cb46810-3118-422b-ab1d-ad3a57ef8bab.png)
### Nachher: 
![Bildschirmfoto 2022-05-07 um 10 26 57](https://user-images.githubusercontent.com/74987472/167246093-da2bde3e-904b-4497-a7cc-26266e1eb362.png)
